### PR TITLE
Use gradle with mojang mappings

### DIFF
--- a/MidiPlayer/build.gradle.kts
+++ b/MidiPlayer/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+  `java-library`
+  id("io.papermc.paperweight.userdev") version "2.0.0-beta.17"
+}
+
+group = "org.primesoft.midiplayer"
+version = "0.4.0"
+description = "A plugin that allows you to play custom music on your server"
+
+java {
+  // Configure the java toolchain. This allows gradle to auto-provision JDK 17 on systems that only have JDK 11 installed for example.
+  toolchain.languageVersion = JavaLanguageVersion.of(17)
+}
+
+dependencies {
+  paperweight.paperDevBundle("1.21.4-R0.1-SNAPSHOT")
+  compileOnly("com.googlecode.json-simple:json-simple:1.1.1")
+}
+
+tasks {
+  compileJava {
+    // Set the release flag. This configures what version bytecode the compiler will emit, as well as what JDK APIs are usable.
+    // See https://openjdk.java.net/jeps/247 for more information.
+    options.release = 17
+  }
+
+  processResources {
+    filteringCharset = Charsets.UTF_8.name()
+    val props =
+      mapOf(
+        "name" to project.name,
+        "version" to project.version,
+        "description" to project.description,
+      )
+    inputs.properties(props)
+    filesMatching("paper-plugin.yml") { expand(props) }
+  }
+}

--- a/MidiPlayer/pom.xml
+++ b/MidiPlayer/pom.xml
@@ -41,19 +41,6 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>                    
-                        <configuration>
-                            <relocations>
-                                <relocation>
-                                    <pattern>org.json.simple</pattern>
-                                    <shadedPattern>org.primesoft.midiplayer.lib.org.json.simple</shadedPattern>
-                                </relocation>
-                            </relocations>
-                            <artifactSet>
-                                <includes>
-                                    <include>com.googlecode.json-simple:json-simple</include>
-                                </includes>
-                            </artifactSet>                            
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -91,7 +78,7 @@
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>
-            <type>jar</type>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/MidiPlayer/src/main/resources/paper-plugin.yml
+++ b/MidiPlayer/src/main/resources/paper-plugin.yml
@@ -1,9 +1,11 @@
-name: ${project.name}
+name: ${name}
 main: org.primesoft.midiplayer.MidiPlayerMain
-version: ${project.version}
+version: ${version}
 authors: [SBPrime]
-api-version: 1.19
-description: ${project.description}
+api-version: 1.21
+description: ${description}
+libraries:
+  - com.googlecode.json-simple:json-simple:1.1.1
 permissions:
   musicplayer.*:
     description: Grants access to all MidiPlayer permissions


### PR DESCRIPTION
This would drop maven support since the yml variables in the plugin yml are slightly different. It uses the paper-plugin.yml which implicitly uses Mojang mappings instead.

https://github.com/PaperMC/paperweight-test-plugin
https://docs.papermc.io/paper/dev/project-setup/#plugin-remapping